### PR TITLE
feat: 자유게시글 조회수 기능 추가

### DIFF
--- a/MUDIUM_Frontend/src/views/board/BoardDetailView.vue
+++ b/MUDIUM_Frontend/src/views/board/BoardDetailView.vue
@@ -19,6 +19,11 @@
         <span class="board-detail-updated">수정시간: {{ convertToKoreanTime(updatedAt) }}</span>
         </div>
     </template>
+    <div class="board-detail-subheader">
+        <div class="board-detail-viewCount">
+        <span class="board-detail-viewCount">조회수: {{ viewCount }}</span>
+        </div>
+    </div>
     <div class="board-detail-content">
         <div class="board-detail-content-read">
             <p>{{ content }}</p>
@@ -41,7 +46,7 @@
     </div>
 
     <Modal v-model:isVisible="showDeleteModal" @confirm="deletePost">
-      정말 삭제하시겠습니까?
+        정말 삭제하시겠습니까?
     </Modal>
 </template>
 
@@ -66,6 +71,7 @@ const likeCount = ref(0);
 const isLiked = ref(false);
 const userId = ref(1);
 const showDeleteModal = ref(false);
+const viewCount = ref(0);
 
 const editPost = () => {
     router.push(`/board/edit/${id.value}`);
@@ -91,7 +97,23 @@ const fetchDetailBoard = async() => {
     createdAt.value = responseDTO.data.createdAt;
     updatedAt.value = responseDTO.data.updatedAt;
     likeCount.value = Number(responseDTO.data.boardLike);
+    viewCount.value = Number(responseDTO.data.viewCount);
 
+    incrementViewCount();
+}
+
+const incrementViewCount = async () => {
+    const viewedPosts = JSON.parse(localStorage.getItem('viewedPosts') || '{}');
+    if (!viewedPosts[id.value]) {
+        viewedPosts[id.value] = true;
+        localStorage.setItem('viewedPosts', JSON.stringify(viewedPosts));
+
+        await fetch(`http://localhost:8080/api/board/${id.value}/count`, {
+            method: 'PUT'
+        });
+
+        viewCount.value++;
+    }
 }
 
 const fetchComments = async () => {
@@ -195,6 +217,14 @@ font-size: 14px;
 color: #666;
 display:flex;
 justify-content: space-between;
+}
+
+.board-detail-viewCount {
+    font-size: 14px;
+    color: #666;
+    display:flex;
+    flex-direction: column;
+    align-items: end;
 }
 
 .board-detail-updated {

--- a/MUDIUM_Frontend/src/views/board/BoardView.vue
+++ b/MUDIUM_Frontend/src/views/board/BoardView.vue
@@ -22,18 +22,20 @@
             <th>작성자</th>
             <th>작성일</th>
             <th>좋아요</th>
+            <th>조회수</th>
           </tr>
         </thead>   
         <tr v-for="pageItem in pageItems" :key="pageItem.id" class="board-tr">
           <td class="td-id">{{ pageItem.id }}</td>
           <td class="td-title">
             <router-link :to="{ name: 'BoardDetailView', params: { id: pageItem.id } }">
-              {{ pageItem.title }}
+              {{ pageItem.title }} [{{ pageItem.comments }}]
             </router-link>
           </td>
           <td class="td-nickname">{{ pageItem.nickname }}</td>
           <td class="td-createdAt">{{ convertToKoreanTime(pageItem.createdAt) }}</td>
           <td class="td-like">{{ pageItem.boardLike }}</td>
+          <td class="td-viewCount">{{ pageItem.viewCount }}</td>
         </tr>
       </table>
     </div> 
@@ -69,7 +71,6 @@ const fetchPageData = async () => {
   pageItems.length = 0;
   pageItems.push(...responseDTO.data.content);
   totalPageNumber.value = responseDTO.data.totalPages;
-
 };
 
 const queryPageData = async () => {
@@ -227,7 +228,7 @@ onMounted(() => {
 }
 
 .td-title {
-  width: 50%;
+  width: 43%;
 }
 
 .td-nickname {
@@ -239,6 +240,11 @@ onMounted(() => {
   text-align: center;
 }
 .td-like {
+  width: 10%;
+  text-align-last: center;
+}
+
+.td-viewCount {
   width: 10%;
   text-align-last: center;
 }


### PR DESCRIPTION
게시글에 조회수 표시 및 조회 시 조회수 증가 기능 추가

---
name: 조회수 기능 추가
about:
1) 게시글 목록 / 게시글 상세조회에서 조회수를 확인할 수 있습니다.
2) 게시글 조회 시 회원 아이디와 조회한 게시글 목록을 로컬 스토리지에 저장합니다.
2-1) 저장된 게시글을 조회 시 아무 일도 일어나지 않습니다.
2-2) 저장되지 않은 게시글을 조회 시 백엔드 서버로 조회수를 증가시키는 요청을 보냅니다.

title: ''
labels: enhancement
assignees: ''

---

## 무슨 이유로 코드를 변경했는가
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 픽스

## 어떤 위험이나 장애가 발견되었는지 (버그 픽스인 경우)
- 
- 

## 어떤 부분에 리뷰어가 집중하면 좋은가
- 로컬 스토리지를 사용하는 부분이 이상한 점은 없는지 확인 부탁드립니다!!

## 관련 스크린 샷 
![image](https://github.com/user-attachments/assets/b6f8a57e-2fd4-4ecc-834d-818fa991688c)
![image](https://github.com/user-attachments/assets/6f7afed9-7bcc-4573-8572-3facf7c37491)


## 테스트 계획 또는 완료 사항
- [ ] 테스트항목 1
- [ ] 테스트항목 2
