### PR TITLE
FIX: 카카오 로그인으로도 회원 번호를 받을 수 있도록 처리

### DIFF
--- a/MUDIUM_Frontend/src/views/musical/MusicalDetailView.vue
+++ b/MUDIUM_Frontend/src/views/musical/MusicalDetailView.vue
@@ -19,7 +19,7 @@
             :rating="scope ? scope.scope : 0"
             :musical-id="musical.musicalId"
             v-if="userStore.userInfo.isLoggedIn"
-            :userId="userStore.userInfo.user_id"
+            :userId="userId"
             @set-rating="setRating"
           />
           <StarRating 
@@ -70,7 +70,7 @@ const performanceList = ref([]);
 const reviews = ref([]);
 const scope = ref({});
 const userStore = useUserStore();
-
+const userId = userStore.userInfo.user_id || parseInt(userStore.userInfo.userId);
 
 const setRating = (newRating) => {
   scope.value.scope = newRating;
@@ -78,7 +78,6 @@ const setRating = (newRating) => {
 
 const fetchPerformanceList = async (id) => {
   try {
-   
     const response = await fetch(`http://localhost:8080/api/performance/${id}`);
     const data = await response.json();
     performanceList.value = data.data;
@@ -88,7 +87,6 @@ const fetchPerformanceList = async (id) => {
 };
 
 const fetchMyScope = async (id) => {
-  const userId = userStore.userInfo.user_id;
   console.log("userId: ", userId);
   try {
     const response = await fetch(`http://localhost:8080/api/scope/${userId}/${id}`);


### PR DESCRIPTION
---
name: 카카오 로그인으로도 회원 번호를 받을 수 있도록 처리
about: 카카오 로그인으로 생성된 회원 번호도 별점 수정에 사용할 수 있도록 수정했습니다.
title: ''
labels: enhancement
assignees: ''

---

## 무슨 이유로 코드를 변경했는가
- [ ] 신규 기능
- [x] 기능 수정
- [ ] 버그 픽스

## 어떤 위험이나 장애가 발견되었는지 (버그 픽스인 경우)
- 
- 

## 어떤 부분에 리뷰어가 집중하면 좋은가
- 

## 관련 스크린 샷 

## 테스트 계획 또는 완료 사항
- [x] 카카오 로그인을 통한 별점 생성  가능
